### PR TITLE
Optimisations and some tidying

### DIFF
--- a/src/FTColumnflow.js
+++ b/src/FTColumnflow.js
@@ -1373,23 +1373,12 @@ var FTColumnflow = (function () {
 			});
 
 			// Check target is a child of viewport
-			if (!this._isDescendant(this.viewport, this.target)) {
+			if (this.viewport.compareDocumentPosition(this.target) < this.viewport.DOCUMENT_POSITION_CONTAINED_BY) {
 				throw new FTColumnflowException('InheritanceException', 'Target element must be a child of the viewport.');
 			}
 
 			// Ensure we have an empty target
 			this.target.innerHTML = '';
-		},
-
-		_isDescendant: function (parent, child) {
-			var node = child.parentNode;
-			while (node !== null) {
-				if (node === parent) {
-					return true;
-				}
-				node = node.parentNode;
-			}
-			return false;
 		}
 	};
 


### PR DESCRIPTION
@georgecrawford just a few small changes:
- get rid of some warnings when compiling with Closure Compiler in advanced mode
- implement a todo that asked for multiple getComputedStyle calls to be merged
- optimise write of initial target subcontainers to the DOM
- remove some unused functions and variables
- add jslint declarations
- remove unused XML support in outerHTML shim
- use compareDocumentPosition instead of looping (and drop _isDescendant)
